### PR TITLE
Support for constants with PHP short array syntax

### DIFF
--- a/TokenReflection/ReflectionConstant.php
+++ b/TokenReflection/ReflectionConstant.php
@@ -358,6 +358,12 @@ class ReflectionConstant extends ReflectionElement implements IReflectionConstan
 			T_NS_C => true,
 			T_TRAIT_C => true
 		);
+		
+		if ( floatval(phpversion()) >= 5.6 ) {
+            		$acceptedTokens['['] = true;
+            		$acceptedTokens[']'] = true;
+            		$acceptedTokens[T_DOUBLE_ARROW] = true;
+        	}
 
 		while (null !== ($type = $tokenStream->getType())) {
 			if (T_START_HEREDOC === $type) {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,11 @@
 			"homepage": "https://github.com/kukulich"
 		}
 	],
-
+	
+	"replace": {
+		"andrewsville/php-token-reflection": "1.*"
+	},
+	
 	"require": {
 		"php": ">=5.3.0",
 		"ext-tokenizer": "*"


### PR DESCRIPTION
Added support for constants with PHP short array syntax. Applicable for PHP 5.6 and above.